### PR TITLE
LiquidXP drops

### DIFF
--- a/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
+++ b/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
@@ -1,11 +1,17 @@
 package magicbees.main.utils.compat;
 
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.event.FMLInterModComms;
+import magicbees.item.types.DropType;
 import magicbees.main.Config;
 import magicbees.main.utils.BlockInterface;
 import magicbees.main.utils.ItemInterface;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 public class EnderIOHelper implements IModHelper {
 
@@ -15,6 +21,7 @@ public class EnderIOHelper implements IModHelper {
 	public static Item itemMaterial;
 	public static Item dust;
 	
+	public static FluidStack fluidXP;
 	
 	public enum AlloyType {
 		ELECTRICAL_STEEL,
@@ -68,6 +75,8 @@ public class EnderIOHelper implements IModHelper {
 		if (isActive()) {
 			getBlocks();
 			getItems();
+			getFluids();
+			setupCrafting();
 		}
 	}
 
@@ -82,5 +91,20 @@ public class EnderIOHelper implements IModHelper {
 		EnderIOHelper.alloyIngot = ItemInterface.getItem(Name, "itemAlloy");
 		EnderIOHelper.itemMaterial = ItemInterface.getItem(Name, "itemMaterial");
 		EnderIOHelper.dust = ItemInterface.getItem(Name, "itemPowderIngot");
+	}
+	
+	private static void getFluids() {
+		EnderIOHelper.fluidXP = FluidRegistry.getFluidStack("xpjuice", 50);
+	}
+	
+	private static void setupCrafting() {
+		NBTTagCompound toSend = new NBTTagCompound();
+		toSend.setInteger("energy", 4000);
+		toSend.setTag("input", new NBTTagCompound());
+		toSend.setTag("output", new NBTTagCompound());
+		ItemStack intellectDrop = Config.drops.getStackForType(DropType.INTELLECT);
+		intellectDrop.writeToNBT(toSend.getCompoundTag("input"));
+		fluidXP.writeToNBT(toSend.getCompoundTag("output"));
+		FMLInterModComms.sendMessage("ThermalExpansion", "CrucibleRecipe", toSend);
 	}
 }

--- a/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
+++ b/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
@@ -95,8 +95,8 @@ public class EnderIOHelper implements IModHelper {
 		EnderIOHelper.dust = ItemInterface.getItem(Name, "itemPowderIngot");
 	}
 	
-	private static void getFluids() {
-		EnderIOHelper.fluidXP = FluidRegistry.getFluidStack("xpjuice", 50);
+	private static void getFluids() {	//getting 1760 mB from 8 BoE, /64 drops = 27.5
+		EnderIOHelper.fluidXP = FluidRegistry.getFluidStack("xpjuice", 25);
 	}
 	
 	private static void setupCrafting() {

--- a/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
+++ b/src/main/java/magicbees/main/utils/compat/EnderIOHelper.java
@@ -2,6 +2,7 @@ package magicbees.main.utils.compat;
 
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInterModComms;
+import forestry.api.recipes.RecipeManagers;
 import magicbees.item.types.DropType;
 import magicbees.main.Config;
 import magicbees.main.utils.BlockInterface;
@@ -23,6 +24,7 @@ public class EnderIOHelper implements IModHelper {
 	
 	public static FluidStack fluidXP;
 	
+	//both ingots and blocks
 	public enum AlloyType {
 		ELECTRICAL_STEEL,
 		ENERGETIC_ALLOY,
@@ -98,13 +100,17 @@ public class EnderIOHelper implements IModHelper {
 	}
 	
 	private static void setupCrafting() {
-		NBTTagCompound toSend = new NBTTagCompound();
-		toSend.setInteger("energy", 4000);
-		toSend.setTag("input", new NBTTagCompound());
-		toSend.setTag("output", new NBTTagCompound());
-		ItemStack intellectDrop = Config.drops.getStackForType(DropType.INTELLECT);
-		intellectDrop.writeToNBT(toSend.getCompoundTag("input"));
-		fluidXP.writeToNBT(toSend.getCompoundTag("output"));
-		FMLInterModComms.sendMessage("ThermalExpansion", "CrucibleRecipe", toSend);
+		RecipeManagers.squeezerManager.addRecipe(10, new ItemStack[]{Config.drops.getStackForType(DropType.INTELLECT)}, EnderIOHelper.fluidXP);
+
+		if(ThermalModsHelper.isActive()){
+			NBTTagCompound toSend = new NBTTagCompound();
+			toSend.setInteger("energy", 4000);
+			toSend.setTag("input", new NBTTagCompound());
+			toSend.setTag("output", new NBTTagCompound());
+			ItemStack intellectDrop = Config.drops.getStackForType(DropType.INTELLECT);
+			intellectDrop.writeToNBT(toSend.getCompoundTag("input"));
+			fluidXP.writeToNBT(toSend.getCompoundTag("output"));
+			FMLInterModComms.sendMessage("ThermalExpansion", "CrucibleRecipe", toSend);
+		}
 	}
 }


### PR DESCRIPTION
Add "crucible recipe" so Fluid Transposer can turn Intellect Drops directly into fluid xpjuice, without bottling as Bottles o' Enchanting.