### PR TITLE
Made beeNuggets compatible with multi-word ingot names

### DIFF
--- a/src/main/java/magicbees/main/Config.java
+++ b/src/main/java/magicbees/main/Config.java
@@ -390,6 +390,11 @@ public class Config
 			LogHelper.info("Found nugget of type " + type.toString());
 			item = type.toString().toLowerCase();
 			item = Character.toString(item.charAt(0)).toUpperCase() + item.substring(1);
+			int space = item.indexOf('_');
+			while(space > -1) {
+				item = item.substring(0,space) + Character.toString(item.charAt(space+1)).toUpperCase() + item.substring(space+2);
+				space = item.indexOf('_');
+			}
 			if (OreDictionary.getOres("ingot" + item).size() <= 0) {
 				if (OreDictionary.getOres("shard" + item).size() <= 0) {
 					LogHelper.info("Disabled nugget " + type.toString());


### PR DESCRIPTION
Extend the nugget de-activation check to use '_' to CamelCase conversion in oredict name of associated ingots.

Will IndexOutOfBounds if somebody puts NUGGET_ for an unknown reason.